### PR TITLE
Fixed quick settings toggles in Gnome 44

### DIFF
--- a/themes/RosePine-Main-BL/gnome-shell/gnome-shell.css
+++ b/themes/RosePine-Main-BL/gnome-shell/gnome-shell.css
@@ -2840,9 +2840,10 @@ StEntry StLabel.hint-text,
 
 .quick-toggle {
   border-radius: 8px;
-  min-width: 12em;
+  /* border-radius: 8px 0 0 8px; */
+  min-width: 1em;
   max-width: 12em;
-  min-height: 40px;
+  min-height: 48px;
   border: none;
   border: 1px solid rgba(224, 222, 244, 0.2);
   background-color: rgba(224, 222, 244, 0.08) !important;
@@ -2904,23 +2905,48 @@ StEntry StLabel.hint-text,
 .quick-menu-toggle:rtl > StBoxLayout {
   padding-left: 0;
 }
+  .quick-menu-toggle .quick-toggle:ltr {
+    border-radius: 8px 0 0 8px; }
+  .quick-menu-toggle .quick-toggle:rtl {
+    border-radius: 0 8px 8px 0; }
+  .quick-menu-toggle .quick-toggle:ltr:last-child {
+    border-radius: 99px; }
+  .quick-menu-toggle .quick-toggle:rtl:last-child {
+    border-radius: 99px; }
 
 .quick-menu-toggle .quick-toggle-arrow {
   background-color: rgba(224, 222, 244, 0.08) !important;
+  border-radius: 8px;
   padding: 6px 10.5px;
+  border: 1px solid rgba(224, 222, 244, 0.2);
+  background-color: rgba(224, 222, 244, 0.08) !important;
   icon-size: 16px !important;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:active {
+  border-radius: 8px;
   background-color: rgba(224, 222, 244, 0.12) !important;
 }
+.quick-menu-toggle .quick-toggle-arrow:checked {
+  transition-duration: 100ms;
+  background-color: #31748f !important;
+  color: #faf4ed;
+  }
+  .quick-menu-toggle .quick-toggle-arrow:checked:hover {
+  background-color: #9ccfd8 !important;
+  color: rgba(0, 0, 0, 0.87);
+  }
+  .quick-menu-toggle .quick-toggle-arrow:hover {
+  background-color: rgba(224, 222, 244, 0.12) !important;
+  }
 
 .quick-menu-toggle .quick-toggle-arrow:ltr {
-  border-radius: 0 6px 6px 0;
+  border-radius: 0 8px 8px 0;
+  border-left-width: 0px;
 }
 
 .quick-menu-toggle .quick-toggle-arrow:rtl {
-  border-radius: 6px 0 0 6px;
+  border-radius: 8px 0 0 8px;
 }
 
 .quick-slider {


### PR DESCRIPTION
The Gnome shell quick toggles no longer overlay the arrows on top of the toggles, which broke the quick settings menu. I updated the CSS to support this change so the arrows can be rendered correctly and adjusted the height of the toggles, also to match the changes in Gnome 44

Before:
![imagen](https://user-images.githubusercontent.com/22871434/236390680-f8c712de-78bc-4ecf-a76c-d8a5b6185778.png)
After:
![imagen](https://user-images.githubusercontent.com/22871434/236390718-55f873e3-44df-4c49-afea-21d14560650a.png)
